### PR TITLE
content: Fix links to 3rd post of Arch Linux

### DIFF
--- a/content/post/arch-linux-base-installation.md
+++ b/content/post/arch-linux-base-installation.md
@@ -13,7 +13,7 @@ This post is part of a series of posts about installing and configuring Arch Lin
 
 1. Base Arch Linux installation
 2. [Arch Linux network configuration]({{< ref "arch-linux-network-configuration" >}})
-3. [Tracking dotfiles]{{< ref "arch-linux-tracking-dotfiles" >}}
+3. [Tracking dotfiles]({{< ref "arch-linux-tracking-dotfiles" >}})
 
 I installed Arch Linux in my new laptop, an [Slimbook](https://slimbook.com/en/) Executive 14".
 I followed the [official installation guide](https://wiki.archlinux.org/title/Installation_guide), however, I had to dig through different pages to install it how I wanted.

--- a/content/post/arch-linux-network-configuration.md
+++ b/content/post/arch-linux-network-configuration.md
@@ -13,7 +13,7 @@ This post is part of a series of posts about installing and configuring Arch Lin
 
 1. [Base Arch Linux installation ]({{< ref "arch-linux-base-installation" >}})
 2. Arch Linux network configuration
-3. [Tracking dotfiles]{{< ref "arch-linux-tracking-dotfiles" >}}
+3. [Tracking dotfiles]({{< ref "arch-linux-tracking-dotfiles" >}})
 
 NOTE because all the operations require root permissions, I logged as root with `sudo su`, so all the commands in this post don't execute with `sudo`.
 

--- a/content/post/arch-linux-tracking-dotfiles.md
+++ b/content/post/arch-linux-tracking-dotfiles.md
@@ -1,6 +1,6 @@
 +++
 description = "PGP and Git configurations to start tracking my dotfiles"
-date = "2025-06-21T16:07:45Z"
+date = "2025-06-21T14:29:45Z"
 title = "Tracking dotfiles"
 social_image = "https://i.pinimg.com/originals/89/b7/d5/89b7d54e3f6fca2f413f4596a4436262.png"
 tags = ["linux-arch", "git", "pgp"]


### PR DESCRIPTION
Fix the links to the 3rd post of the Arch Linux series posts and the publishing date because it was in the future and Hugo cannot create links for post with future dates.